### PR TITLE
Merge Kubelet k8s-args node-labels with defaults

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+group :test do
+  gem 'bosh-template'
+  gem 'rspec'
+  gem 'rubocop'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,48 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.0)
+    bosh-template (2.2.0)
+      semi_semantic (~> 1.2.0)
+    diff-lcs (1.3)
+    jaro_winkler (1.5.2)
+    parallel (1.13.0)
+    parser (2.6.0.0)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
+    rainbow (3.0.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    rubocop (0.63.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.4.0)
+    ruby-progressbar (1.10.0)
+    semi_semantic (1.2.0)
+    unicode-display_width (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bosh-template
+  rspec
+  rubocop
+
+BUNDLED WITH
+   2.0.1

--- a/jobs/kubelet-windows/spec
+++ b/jobs/kubelet-windows/spec
@@ -41,9 +41,6 @@ properties:
         docker-only: null
   no_proxy:
     description: no_proxy env var for cloud provider interactions, i.e. for the kubelet
-  labels:
-    description: '<Warning: Alpha feature> Labels to add when registering the node
-      in the cluster.  Labels must be key=value pairs separated by '',''.'
   tls.kubelet:
     description: Certificate and private key for the Kubernetes worker
     parameters:

--- a/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
@@ -26,9 +26,13 @@ $env:PATH+=";C:\var\vcap\packages\docker\docker\;"
   if iaas=="vsphere"
     labels << "failure-domain.beta.kubernetes.io/zone=#{spec.az}"
   end
-  if_p("labels") do |node_labels|
-    labels += node_labels.map {|k,v| "#{k}=#{v}"}
+
+  if_p('k8s-args') do |args|
+    custom_labels = args.fetch('node-labels', "").split(",")
+    labels = custom_labels + labels
+    args.delete('node-labels')
   end
+
   labels = labels.join(',')
 %>
 

--- a/spec/kubelet_windows_ctl_spec.rb
+++ b/spec/kubelet_windows_ctl_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'spec_helper'
+
+def get_node_labels(rendered_kubelet_ctl)
+  node_labels = rendered_kubelet_ctl.split("\n").select { |line| line[/--node-labels=/i] }
+  expect(node_labels.length).to be(1)
+  labels = node_labels[0].match(/--node-labels=(.*) `/).captures[0]
+  labels.split(",")
+end
+
+describe 'kubelet_ctl' do
+  let(:rendered_template) do
+    compiled_template('kubelet-windows', 'bin/kubelet_ctl.ps1', {}, {}, {}, 'z1', 'fake-bosh-ip', 'fake-bosh-id')
+  end
+
+  it 'labels the kubelet with its own az' do
+    expect(rendered_template).to include(',bosh.zone=z1')
+  end
+
+  it 'labels the kubelet with the spec ip' do
+    expect(rendered_template).to include('spec.ip=fake-bosh-ip')
+  end
+
+  it 'labels the kubelet with the bosh id' do
+    expect(rendered_template).to include(',bosh.id=fake-bosh-id')
+  end
+
+  it 'labels the kubelet with custom labels' do
+    manifest_properties = {
+      'k8s-args' => {
+        'node-labels' => 'foo=bar,k8s.node=custom'
+      }
+    }
+    rendered_kubelet_ctl = compiled_template('kubelet-windows', 'bin/kubelet_ctl.ps1', manifest_properties, {}, {}, 'z1', 'fake-bosh-ip', 'fake-bosh-id')
+    labels = get_node_labels(rendered_kubelet_ctl)
+
+    expect(labels).to include('bosh.zone=z1')
+    expect(labels).to include('spec.ip=fake-bosh-ip')
+    expect(labels).to include('bosh.id=fake-bosh-id')
+    expect(labels).to include('k8s.node=custom')
+    expect(labels).to include('foo=bar')
+  end
+
+  it 'labels the kubelet with default labels' do
+    manifest_properties = {
+      'k8s-args' => {
+      }
+    }
+    rendered_kubelet_ctl = compiled_template('kubelet-windows', 'bin/kubelet_ctl.ps1', manifest_properties, {}, {}, 'z1', 'fake-bosh-ip', 'fake-bosh-id')
+    labels = get_node_labels(rendered_kubelet_ctl)
+
+    expect(labels).to include('bosh.zone=z1')
+    expect(labels).to include('spec.ip=fake-bosh-ip')
+    expect(labels).to include('bosh.id=fake-bosh-id')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'support/template_helpers'
+
+RSpec.configure do |config|
+  config.include TemplateHelpers
+end

--- a/spec/support/template_helpers.rb
+++ b/spec/support/template_helpers.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'bosh/template/renderer'
+require 'yaml'
+
+module TemplateHelpers
+  include Bosh::Template::PropertyHelper
+
+  def compiled_template(job_name, template_name, manifest_properties = {}, links = {}, network_properties = [], az = '', ip = '', id = '', instance_name: '')
+    manifest = emulate_bosh_director_merge(job_name, manifest_properties, links, network_properties, az, ip, id, instance_name)
+
+    renderer = Bosh::Template::Renderer.new(context: manifest)
+    renderer.render("jobs/#{job_name}/templates/#{template_name}.erb")
+  end
+
+  # Trying to emulate bosh director Bosh::Director::DeploymentPlan::Job#extract_template_properties
+  def emulate_bosh_director_merge(job_name, manifest_properties, links, network_properties, az, ip, id, instance_name)
+    job_spec = YAML.load_file("jobs/#{job_name}/spec")
+    spec_properties = job_spec['properties']
+
+    default_property_values = {}
+    spec_properties.each_pair do |name, definition|
+      default_value = definition['default']
+      copy_property(default_property_values, {}, name, default_value)
+    end
+
+    effective_properties = recursive_merge(default_property_values, manifest_properties)
+
+    links.each do |link_name, contents|
+      next unless link_name == 'cloud-provider'
+
+      link_spec = YAML.load_file("jobs/#{link_name}/spec")
+      link_spec_properties = link_spec['properties']
+
+      default_link_property_values = {}
+      link_spec_properties.each_pair do |name, definition|
+        default_value = definition['default']
+        copy_property(default_link_property_values, {}, name, default_value)
+      end
+
+      link_properties = recursive_merge(default_link_property_values, contents['properties'])
+      contents['properties'] = link_properties
+    end
+
+    {
+      'properties' => effective_properties,
+      'networks' => network_properties,
+      'links' => links,
+      'az' => az,
+      'ip' => ip,
+      'id' => id,
+      'name' => instance_name
+    }.to_json
+  end
+
+  def recursive_merge(first, other)
+    first.merge(other) do |_, old_value, new_value|
+      if old_value.class == Hash && new_value.class == Hash
+        recursive_merge(old_value, new_value)
+      else
+        new_value
+      end
+    end
+  end
+end


### PR DESCRIPTION
Brings the Windows Kubelet ctl script in line with the Linux version.
Retires the old labels spec property.