### PR TITLE
Allow customizing windows CIDRs

### DIFF
--- a/jobs/flanneld-windows/spec
+++ b/jobs/flanneld-windows/spec
@@ -12,9 +12,9 @@ packages:
 - cni-windows
 
 properties:
-  pod-network-cidr:
-    description: The pod networking cidr for pod network overlay
-    default: "10.200.0.0/16"
+  kubedns-service-ip:
+    description: The service cluster IP for DNS, must reside within service-cluster-cidr set for kube-apiserver
+    default: "10.100.200.10"
   backend-type:
     description: The network backend to use
     default: "win-overlay"
@@ -28,6 +28,10 @@ properties:
 consumes:
 - name: etcd
   type: etcd
+- name: flanneld
+  type: flanneld
+- name: kube-apiserver
+  type: kube-apiserver
 
 provides:
 - name: flanneld-windows

--- a/jobs/flanneld-windows/templates/bin/flanneld_ctl.ps1.erb
+++ b/jobs/flanneld-windows/templates/bin/flanneld_ctl.ps1.erb
@@ -22,6 +22,14 @@ trap { $host.SetShouldExit(1) }
 
 function start_flanneld {
   <% etcd_endpoints = link('etcd').instances.map { |server| get_url(server, 2379) }.join(",") %>
+  <%
+    service_cidr = "10.100.200.0/24"
+    link('kube-apiserver').p('k8s-args').each do |flag, value|
+      if flag == "service-cluster-ip-range"
+        service_cidr = value
+      end
+    end
+  %>
 
   mkdir -force /etc/cni/net.d
   $confFile= '
@@ -35,7 +43,7 @@ function start_flanneld {
         "isDefaultGateway": true,
         "type": "<%= p('backend-type') %>",
         "dns": {
-          "nameservers": ["10.100.200.10"],
+          "nameservers": ["<%= p("kubedns-service-ip") %>"],
           "search": ["svc.cluster.local"]
         },
         "policies": [
@@ -44,8 +52,8 @@ function start_flanneld {
             "Value": {
               "Type": "OutBoundNAT",
               "ExceptionList": [
-                "<%= p('pod-network-cidr') %>",
-                "10.100.200.0/12",
+                "<%= link("flanneld").p('pod-network-cidr') %>",
+                "<%= service_cidr %>",
                 "<%= spec.ip.split(".")[0...-1].append(0).join(".") %>/24"
               ]
             }
@@ -54,7 +62,7 @@ function start_flanneld {
             "Name": "EndpointPolicy",
             "Value": {
               "Type": "ROUTE",
-              "DestinationPrefix": "10.100.200.0/24",
+              "DestinationPrefix": "<%= service_cidr %>",
               "NeedEncap": true
             }
           },


### PR DESCRIPTION
Move to using links to consume the same pod cidr as the Linux jobs. Unfortunately we can't expose a link to the `apply-specs` job to pull the same `kubedns-service-ip` as is specified there, since apparently BOSH [doesn't support](https://github.com/cloudfoundry/bosh/issues/1639) exposing links to errand jobs.

Depends on https://github.com/cloudfoundry-incubator/kubo-release/pull/349