### PR TITLE
Add docker job

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,6 +2,9 @@ cni/cni-plugins-windows-amd64-c74e0e996.tgz:
   size: 9678154
   object_id: da0e8048-675b-4701-68e9-7db89e88723b
   sha: 02c4d67a17a28c26cc471e56bf01dcacd104b346
+docker-windows/docker-18-09-9.zip:
+  size: 49417290
+  sha: 269a6baacd95e7b59f2e4695cca0b662359e497e
 flannel-v0.11.0-windows-amd64.tar.gz:
   size: 9488010
   object_id: 968eac5f-3008-4bcf-5481-f3f4179162d4

--- a/jobs/docker-windows/spec
+++ b/jobs/docker-windows/spec
@@ -1,0 +1,10 @@
+---
+name: docker-windows
+
+templates:
+  pre-start.ps1: bin/pre-start.ps1
+
+packages:
+- docker-windows
+
+properties:

--- a/jobs/docker-windows/templates/pre-start.ps1
+++ b/jobs/docker-windows/templates/pre-start.ps1
@@ -1,0 +1,23 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$mtx = New-Object System.Threading.Mutex($false, "PathMutex")
+
+if (!$mtx.WaitOne(300000)) {
+  throw "Could not acquire PATH mutex"
+}
+
+$AddedFolder= "C:\var\vcap\packages\docker-windows\docker\"
+
+$OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
+
+if (-not $OldPath.Contains($AddedFolder)) {
+  $NewPath=$OldPath+';'+$AddedFolder
+  Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+}
+
+$mtx.ReleaseMutex()
+
+C:\var\vcap\packages\docker-windows\docker\dockerd --register-service
+
+Start-Service Docker

--- a/packages/docker-windows/packaging
+++ b/packages/docker-windows/packaging
@@ -1,0 +1,13 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$BOSH_INSTALL_TARGET = Resolve-Path $env:BOSH_INSTALL_TARGET
+$path=(Get-ChildItem "docker-windows/docker*.zip").FullName
+
+if (Get-Command Expand-Archive -ErrorAction SilentlyContinue) {
+  Expand-Archive -Path $path -DestinationPath ${BOSH_INSTALL_TARGET}
+} else {
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($path, ${BOSH_INSTALL_TARGET})
+}
+

--- a/packages/docker-windows/spec
+++ b/packages/docker-windows/spec
@@ -1,0 +1,7 @@
+---
+name: docker-windows
+
+dependencies: []
+
+files:
+- docker-windows/docker-*.zip


### PR DESCRIPTION
Removes reliance on windows-tools-release which has too many other jobs in it, causing licensing issues. I think ideally some day we can move this to https://github.com/cloudfoundry-incubator/docker-boshrelease but it was reverted there for unclear reasons so let's just avoid drama for now.