### PR TITLE
Support for NSX-T windows containers

### DIFF
--- a/jobs/kube-proxy-windows/spec
+++ b/jobs/kube-proxy-windows/spec
@@ -36,3 +36,9 @@ properties:
           CPUManager: true
           DryRun: false
         cleanup: false
+  cni_init_file:
+    description: "File used by kube-proxy to check if cni is initialized"
+    default: "/run/flannel/subnet.env"
+  hns_network_type:
+    description: "Type of HNS Network to be used to find the HNS Network Name"
+    default: "L2Bridge"

--- a/jobs/kube-proxy-windows/templates/bin/kube_proxy_ctl.ps1.erb
+++ b/jobs/kube-proxy-windows/templates/bin/kube_proxy_ctl.ps1.erb
@@ -8,18 +8,18 @@ function ensure_kubelet_is_running {
 }
 
 function start_kube_proxy {
-  $network = Get-HnsNetwork | ? Type -Eq L2Bridge
+  $network = Get-HnsNetwork | ? Type -Eq <%= p('hns_network_type') %>
   $env:KUBE_NETWORK = $network.Name
 
   C:\var\vcap\packages\kubernetes-windows\bin\kube-proxy.exe -v 5 --config /var/vcap/jobs/kube-proxy-windows/config/config.yml
 }
 
 function check_for_networking {
-  $subnetConfig="/run/flannel/subnet.env"
+  $cniInitFile='<%= p('cni_init_file') %>'
 
-  if (-not ([System.IO.File]::Exists($subnetConfig)))
+  if (-not ([System.IO.File]::Exists($cniInitFile)))
   {
-    throw "$subnetConfig does not exist, waiting for flannel initialization"
+    throw "$cniInitFile does not exist, waiting for CNI initialization"
   }
 }
 

--- a/jobs/kubelet-windows/spec
+++ b/jobs/kubelet-windows/spec
@@ -51,6 +51,9 @@ properties:
     description: CA certificate of the authority granting access to kubelet server
   tls.kubernetes:
     description: Certificate and private key for the Kubernetes master
+  cni_init_file:
+    description: "File used by kubelet to check if cni is initialized"
+    default: "/run/flannel/subnet.env"
 consumes:
 - name: cloud-provider
   optional: true

--- a/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
@@ -105,11 +105,11 @@ function start_kubelet {
 }
 
 function check_for_networking {
-  $subnetConfig="/run/flannel/subnet.env"
+  $cniInitFile='<%= p('cni_init_file') %>'
 
-  if (-not ([System.IO.File]::Exists($subnetConfig)))
+  if (-not ([System.IO.File]::Exists($cniInitFile)))
   {
-    throw "$subnetConfig does not exist, waiting for flannel initialization"
+    throw "$cniInitFile does not exist, waiting for CNI initialization"
   }
 }
 


### PR DESCRIPTION
In order to support windows containers on NSX-T require the following changes:

1. Kubelet and kube-proxy are looking for a flannel file to indicate if cni has been initialized. Making this a parameter so that CNI owners can pass in a file that can be checked to indicate if networking is ready
2. kube-proxy is getting HNS Network Name by doing a search on HNS network of type L2Bridge. For NSX-T the network type will be transparent. Making this a parameter so that CNI owners can pass in the type of HNS network to be searched
